### PR TITLE
Simplify environment

### DIFF
--- a/.github/workflows/jupyternotebook.yml
+++ b/.github/workflows/jupyternotebook.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7.7]
+        python-version: [3.7]
         
     steps:
     - uses: actions/checkout@v2

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@ name: nma
 channels:
   - conda-forge
 dependencies:
-  - matplotlib=3.2.1
-  - numpy=1.18.1
-  - numpy-base=1.18.1
-  - python=3.7.7
-  - scipy=1.4.1
+  - matplotlib
+  - numpy
+  - python=3.7
+  - scipy
+  - ipywidgets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-matplotlib=3.2.1
-numpy=1.18.1
-numpy-base=1.18.1
-scipy=1.4.1
+matplotlib
+numpy
+scipy
 ipywidgets


### PR DESCRIPTION
A few years back in CCNSS we struggled to support Keras running on jupyter notebook on MS Windows in Chinese. The solution was to let these library managers sort out the library environment automatically by removing version info from `requirements.txt`/`environment.yml`.

repo2docker advises to be specific about library versions but that introduces management overhead to keep them updated, and s not reflected by their configuration examples:
https://github.com/binder-examples/python-conda_pip/blob/master/environment.yml
https://github.com/binder-examples/requirements/blob/master/requirements.txt

If we do not specify library versions, CI to check compatibility with current versions every week or so and would be alerted of any incompatibilities.

This pull request implements changes to configuration files of CI and library managers.