### PR TITLE
Change how static files are named, and simplify workflow

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -30,7 +30,6 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r requirements.txt
           pip install nbconvert
-          sudo apt-get install pandoc
 
       - name: Install XKCD fonts
         run: |


### PR DESCRIPTION
This should avoid getting duplicates of the static images with new filenames
if additional cells (e.g. Youtube video links) are inserted during the
review process.

Additionally, in figuring out how to do this, I realized we didn't need the
RSTExporter machinery, so this simplifies the build by relieving the
dependency on pandoc.