### PR TITLE
Only do tutorials processing on tutorial notebooks

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -59,7 +59,7 @@ jobs:
           git add '**/static/*.png'
           git add '**/solutions/*.py'
           git add '**/README.md'
-          git commit -m "Process tutorial notebooks"
+          git diff-index --quiet HEAD || git commit -m "Process tutorial notebooks"
 
       - name: Push post-processed notebooks
         if: ${{ success() }}

--- a/ci/process_notebooks.py
+++ b/ci/process_notebooks.py
@@ -88,15 +88,15 @@ def main(arglist):
 
     # TODO Check compliancy with PEP8, generate a report, but don't fail
 
-    # TODO Check notebook name format?
-    # (If implemented, update the CI workflow to only run on tutorials)
-
     # Further filter the notebooks to run post-processing only on tutorials
     tutorials = {
         nb_path: nb
         for nb_path, nb in notebooks.items()
         if nb_path.startswith("tutorials")
     }
+
+    # TODO Check notebook name format?
+    # (If implemented, update the CI workflow to only run on tutorials)
 
     # Post-process notebooks to remove solution code and write both versions
     for nb_path, nb in tutorials.items():

--- a/ci/process_notebooks.py
+++ b/ci/process_notebooks.py
@@ -91,8 +91,15 @@ def main(arglist):
     # TODO Check notebook name format?
     # (If implemented, update the CI workflow to only run on tutorials)
 
+    # Further filter the notebooks to run post-processing only on tutorials
+    tutorials = {
+        nb_path: nb
+        for nb_path, nb in notebooks.items()
+        if nb_path.startswith("tutorials")
+    }
+
     # Post-process notebooks to remove solution code and write both versions
-    for nb_path, nb in notebooks.items():
+    for nb_path, nb in tutorials.items():
 
         # Extract components of the notebook path
         nb_dir, nb_fname = os.path.split(nb_path)


### PR DESCRIPTION
As a result, PRs that commit notebooks somewhere other than `tutorials/` will get checked, but not generate downstream derivatives. See #187 