### PR TITLE
Add script for linting tutorial notebooks

### DIFF
--- a/ci/lint_tutorial.py
+++ b/ci/lint_tutorial.py
@@ -1,0 +1,160 @@
+import os
+import io
+import re
+import sys
+import argparse
+import tempfile
+import subprocess
+import collections
+import nbformat
+from pyflakes.api import check
+from pyflakes.reporter import Reporter
+
+
+def main(arglist):
+
+    args = parse_args(arglist)
+
+    _, fname = os.path.split(args.path)
+
+    script, cell_lines = extract_code(args.path)
+    warnings, errors = check_code(script)
+    line_map = remap_line_numbers(cell_lines)
+    violations = check_style(script)
+
+    if args.brief:
+        pass
+    else:
+        report_verbose(fname, line_map, warnings, errors, violations)
+
+
+def parse_args(arglist):
+
+    parser = argparse.ArgumentParser("Lint a notebook")
+    parser.add_argument("path", help="Path to notebook file")
+    parser.add_argument("--brief", action="store_true",
+                        help="Print brief report (useful for aggregating")
+
+    return parser.parse_args(arglist)
+
+
+def extract_code(nb_fname):
+    """Turn code cells from notebook intro a script, track cell sizes."""
+    with open(nb_fname) as f:
+        nb = nbformat.read(f, nbformat.NO_CONVERT)
+
+    script_lines = []
+    cell_lengths = []
+    for cell in nb.get("cells", []):
+        if cell["cell_type"] == "code":
+            cell_lines = cell.get("source", "").split("\n")
+            cell_lengths.append(len(cell_lines))
+            for line in cell_lines:
+                if line and line[0] in ["!", "%"]:  # IPython syntax
+                    line = "# " + line
+                script_lines.append(line)
+
+    script = "\n".join(script_lines)
+
+    return script, cell_lengths
+
+
+def check_code(script):
+    """Run pyflakes checks over the script and capture warnings/errors."""
+    errors = io.StringIO()
+    warnings = io.StringIO()
+    reporter = Reporter(warnings, errors)
+    check(script, "notebook", reporter)
+
+    warnings.seek(0)
+    errors.seek(0)
+
+    return warnings, errors
+
+
+def check_style(script):
+    """Write a temporary script and run pycodestyle (PEP8) on it."""
+    with tempfile.NamedTemporaryFile("w", suffix=".py") as f:
+        f.write(script)
+        res = subprocess.run(["pycodestyle", f.name], capture_output=True)
+
+    output = res.stdout.decode().replace(f.name, "f").split("\n")
+
+    if not output:
+        return collections.Counter()
+
+    error_classes = []
+    pat = re.compile(r"^f:\d+:\d+: (\w\d{3}) (.*)$")
+    for line in output:
+        m = pat.match(line)
+        if m is not None:
+            error_classes.append(f"{m.group(1)} ({m.group(2)})")
+
+    return collections.Counter(error_classes)
+
+
+def remap_line_numbers(cell_lines):
+    """Create a mapping from script line number to notebook cell/line."""
+    line_map = {}
+    cell_start = 0
+    for cell, cell_length in enumerate(cell_lines, 1):
+        for line in range(1, cell_length + 1):
+            line_map[cell_start + line] = cell, line
+        cell_start += cell_length
+    return line_map
+
+
+def report_verbose(fname, line_map, warnings, errors, violations):
+    """Report every pyflakes problem and more codestyle information."""
+    s = f"Code report for {fname}"
+    print("", s, "=" * len(s), "", sep="\n")
+
+    s = "Quality (pyflakes)"
+    print("", s, "-" * len(s), "", sep="\n")
+
+    warning_lines = reformat_line_problems(warnings, line_map)
+    error_lines = reformat_line_problems(errors, line_map, "ERROR in ")
+
+    issues = warning_lines + error_lines
+    print(f"Total code issues: {len(issues)}")
+    if issues:
+        print()
+        print("\n".join(warning_lines + error_lines))
+
+    s = "Style (pycodestyle)"
+    print("", s, "-" * len(s), "", sep="\n")
+
+    n = len(list(violations.elements()))
+    print(f"Total PEP8 violations: {n}")
+
+    # TODO parametrize n_most_common
+    if violations:
+        print()
+        print("Most common problems:")
+        for code, count in violations.most_common(5):
+            print(f" - {count} instances of {code}")
+
+    print("")
+
+
+def reformat_line_problems(stream, line_map, prefix=""):
+    """Reformat a pyflakes output stream for notebook cells."""
+    pat = re.compile(r"^\w*:(\d+):\d+ (.+)$")
+
+    new_lines = []
+    orig_lines = stream.read().splitlines()
+
+    for line in orig_lines:
+        m = pat.match(line)
+        if m:
+            cell, line = line_map[int(m.group(1))]
+            new_lines.append(
+                f"{prefix}Cell {cell}, Line {line}: {m.group(2)}"
+            )
+
+    return new_lines
+
+
+if __name__ == "__main__":
+
+    main(sys.argv[1:])

--- a/ci/lint_tutorial.py
+++ b/ci/lint_tutorial.py
@@ -1,4 +1,17 @@
-"""Script for linting tutorial notebooks."""
+"""Lint tutorial notebooks with pyflakes and pycodestyle (aka flake8).
+
+Running this script on a notebook will print a report of issues flagged by
+pyflakes (which checks some aspects of code quality) and pycodestyle (which
+checks adherence to the PEP8 stylistic standards).
+
+Note that these checks do not capture all potential issues with a codebase,
+and some checks will false-alarm because of deliberate choices we have made
+about how to write tutorials. Nevertheless, this can be an easy way to flag
+potential issues.
+
+Requires nbformat (part of Jupyter) and flake8.
+
+"""
 import os
 import io
 import re
@@ -20,18 +33,18 @@ def main(arglist):
 
     script, cell_lines = extract_code(args.path)
     warnings, errors = check_code(script)
-    line_map = remap_line_numbers(cell_lines)
     violations = check_style(script)
 
     if args.brief:
         report_brief(fname, warnings, errors, violations)
     else:
+        line_map = remap_line_numbers(cell_lines)
         report_verbose(fname, warnings, errors, violations, line_map)
 
 
 def parse_args(arglist):
 
-    parser = argparse.ArgumentParser("Lint a notebook")
+    parser = argparse.ArgumentParser(__doc__)
     parser.add_argument("path", help="Path to notebook file")
     parser.add_argument("--brief", action="store_true",
                         help="Print brief report (useful for aggregating)")

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - scikit-learn
   - pytorch
   - ipywidgets
+  - flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 scikit-learn
 torch
 ipywidgets
+flake8


### PR DESCRIPTION
This is a work in progress, but it is useful for getting some measure of the issues in a notebook.

It can be run in two ways. By default, it reports every `pyflakes` issue (with line numbers realigned with notebook code cells) along with the total number of PEP8 violations and the most common PEP8 error codes:

```
$ python ci/lint_tutorial.py tutorials/W2D1_BayesianStatistics/W2D1_Tutorial1.ipynb

Code report for W2D1_Tutorial1.ipynb
====================================

Quality (pyflakes)
------------------

Total code issues: 8

Cell 2, Line 3: 'time' imported but unused
Cell 2, Line 5: 'scipy as sp' imported but unused
Cell 2, Line 6: 'math' imported but unused
Cell 2, Line 7: 'random' imported but unused
Cell 2, Line 8: 'os' imported but unused
Cell 2, Line 11: 'IPython.display' imported but unused
Cell 4, Line 67: local variable 'fig' is assigned to but never used
Cell 7, Line 2: redefinition of unused 'my_gaussian' from line 109

Style (pycodestyle)
-------------------

Total PEP8 violations: 144

Common problems:
- 21 instances of E266 (too many leading '#' for block comment)
- 17 instances of W291 (trailing whitespace)
- 17 instances of W293 (blank line contains whitespace)
- 9 instances of E402 (module level import not at top of file)
- 7 instances of E265 (block comment should start with '# ')
- 7 instances of E128 (continuation line under-indented for visual indent)
- 6 instances of E226 (missing whitespace around arithmetic operator)
- 6 instances of E305 (expected 2 blank lines after class or function definition, found 1)
- 6 instances of E251 (unexpected spaces around keyword / parameter equals)
- 5 instances of E302 (expected 2 blank lines, found 1)
```

you can also run it with `--brief` and it reports just the number of pyflakes and pep8 issues. This is useful for batching and then aggregating statistics for all the tutorials. For instance, here is the current distribution of issues:

![image](https://user-images.githubusercontent.com/315810/86304215-2e2b2480-bbdc-11ea-8b6d-79366dc3d527.png)
