### PR TITLE
Define a common NMA style file

### DIFF
--- a/nma.mplstyle
+++ b/nma.mplstyle
@@ -3,8 +3,8 @@ figure.autolayout : True
 font.size : 15
 xtick.labelsize : small
 ytick.labelsize : small
-xtick.major.size : 5
-ytick.major.size : 5
 legend.fontsize : small
 axes.spines.top : False
 axes.spines.right : False
+xtick.major.size : 5
+ytick.major.size : 5

--- a/nma.mplstyle
+++ b/nma.mplstyle
@@ -1,0 +1,10 @@
+figure.figsize : 8, 6
+figure.autolayout : True
+font.size : 15
+xtick.labelsize : small
+ytick.labelsize : small
+xtick.major.size : 5
+ytick.major.size : 5
+legend.fontsize : small
+axes.spines.top : False
+axes.spines.right : False


### PR DESCRIPTION
This provides centralized setting of rcParams. We can point our notebooks at it in a hidden cell, like:

```python
style_url = "https://raw.githubusercontent.com/NeuromatchAcademy/course-content/master/nma.mplstyle"
plt.style.use(style_url)
```

Here is what a simple plot looks like:

![image](https://user-images.githubusercontent.com/315810/86837394-d6be0600-c06c-11ea-9212-2a781887842e.png)

It is a pretty simple style:

- Set 8 x 6 as the default figure size (which should already be present in every tutorial)
- Increase the default text sizes (multiple tutorials were doing this already, and I think it's a good idea)
- Remove the top and right spines (a personal preference)
- tight_layout is used by default

Otherwise, things look more or less like normal matplotlib plots.

I am open to defining a custom color palette, or having other distinguishing  But I don't want to spend a ton of time on it.

Either way, once this PR is merged, notebooks can replace their figure setup code with the line above, and then they will adapt to the latest version of the style file.