### PR TITLE
fix for exercise 11 so that v[0] = el is graphed

### DIFF
--- a/tutorials/W0D1_PythonWorkshop1/W0D1_Tutorial1.ipynb
+++ b/tutorials/W0D1_PythonWorkshop1/W0D1_Tutorial1.ipynb
@@ -1701,10 +1701,10 @@
     "\n",
     "**Suggestions**\n",
     "* Use `np.linspace` to initialize a numpy array `t_range` with `num=step_end=100` values from `0` to `t_max`\n",
-    "* Use `np.ones` to initialize a numpy array `v` with `step_end` leak potential values `el`\n",
+    "* Use `np.ones` to initialize a numpy array `v` with `step_end + 1` leak potential values `el`\n",
     "* Pre-compute `step_end` synaptic current values in numpy array `syn` with `np.random.random(step_end)` for `step_end` random numbers\n",
     "* Iterate for numerical integration of `v`\n",
-    "* Since `v[0]=el`, we should iterate for `step_end - 1` steps, for example by skipping `step=0`. Why?"
+    "* Why do we need a `v` array size of `step_end + 1`?"
    ]
   },
   {
@@ -1745,7 +1745,7 @@
     "# initialize step_end, t_range, v and syn\n",
     "step_end = int(t_max/dt)\n",
     "t_range = np.linspace(0, t_max, num=step_end)\n",
-    "v = el * np.ones(step_end)\n",
+    "v = el * np.ones(step_end + 1)\n",
     "\n",
     "# --> insert your code here\n",
     "\n",
@@ -1755,7 +1755,7 @@
     "plt.xlabel('time (s)')\n",
     "plt.ylabel(r'$V_m$ (V)')\n",
     "\n",
-    "plt.plot(t_range, v, 'k.')\n",
+    "plt.plot(t_range, v[:-1], 'k.')\n",
     "plt.show()"
    ]
   },
@@ -1797,13 +1797,12 @@
     "# initialize step_end, t_range, v and syn\n",
     "step_end = int(t_max / dt)\n",
     "t_range = np.linspace(0, t_max, num=step_end)\n",
-    "v = el * np.ones(step_end)\n",
-    "syn = i_mean * (1 + 0.1 * (t_max/dt) ** (0.5) * (2 * np.random.random(step_end) - 1))\n",
+    "v = el * np.ones(step_end + 1)\n",
+    "syn = i_mean * (1 + 0.1 * np.sqrt(t_max/dt) * (2 * np.random.random(step_end) - 1))\n",
     "\n",
-    "# loop for step_end - 1 steps\n",
-    "for step in range(1, step_end):\n",
-    "\n",
-    "  v[step] = v[step - 1] + (dt / tau) * (el - v[step - 1] + r * syn[step])\n",
+    "# loop for step_end steps\n",
+    "for step in range(step_end):\n",
+    "  v[step + 1] = v[step] + (dt / tau) * (el - v[step] + r * syn[step])\n",
     "\n",
     "with plt.xkcd():\n",
     "  # initialize the figure\n",
@@ -1812,7 +1811,7 @@
     "  plt.xlabel('time (s)')\n",
     "  plt.ylabel(r'$V_m$ (V)')\n",
     "\n",
-    "  plt.plot(t_range, v, 'k.')\n",
+    "  plt.plot(t_range, v[:-1], 'k.')\n",
     "  plt.show()"
    ]
   },


### PR DESCRIPTION
Further to #256 and #243...

Modified W0D1_Tutorial1.ipynb so that `process_notebooks.py` from the `ci` folder can auto-create all needed files.

The problem with exercise 11 is that it didn't plot `v[0] = el` as exercise 7 did. 

Further issues: 
* it truncated the plot by 1 `v` value
* it time shifted `v` plots left by one step
* random values for `syn` were displaced one step higher