### PR TITLE
Add exercise verification to CI

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -45,7 +45,14 @@ jobs:
           output: " "
 
       - name: Process notebooks
-        run: python ci/process_notebooks.py ${{ steps.changes.outputs.files}}
+        run: |
+          nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
+          python ci/process_notebooks.py $nbs
+          if [[ ${{ github.event.head_commit.message }} != *"skip verify"* ]];
+            then for nb in nbs; do
+              python ci/verify_exercises.py $nb
+            done
+          fi
 
       - name: Update READMEs
         run: python ci/generate_tutorial_readmes.py

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -48,11 +48,7 @@ jobs:
         run: |
           nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
           python ci/process_notebooks.py $nbs
-          if [[ ${{ github.event.head_commit.message }} != *"skip verify"* ]];
-            then for nb in nbs; do
-              python ci/verify_exercises.py $nb
-            done
-          fi
+          if [[ ${{ github.event.head_commit.message }} != *"skip verify"* ]]; python ci/verify_exercises.py $nbs; fi
 
       - name: Update READMEs
         run: python ci/generate_tutorial_readmes.py
@@ -62,7 +58,7 @@ jobs:
           python ci/find_unreferenced_content.py > to_remove.txt
           if [ -s to_remove.txt ]; then git rm --pathspec-from-file=to_remove.txt; fi
 
-      - name: Commit processed files
+      - name: Commit post-processed files
         if: ${{ success() }}
         run: |
           git config --local user.email "action@github.com"
@@ -73,7 +69,7 @@ jobs:
           git add '**/README.md'
           git diff-index --quiet HEAD || git commit -m "Process tutorial notebooks"
 
-      - name: Push post-processed notebooks
+      - name: Push post-processed files
         if: ${{ success() }}
         uses: ad-m/github-push-action@v0.6.0
         with:

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -49,7 +49,8 @@ jobs:
           nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
           python ci/process_notebooks.py $nbs
           readonly local last_commit_log=$(git log -1 --pretty=format:"%s")
-          python ci/verify_exercises.py $nbs --c '$last_commit_log'
+          echo $last_commit_log
+          python ci/verify_exercises.py $nbs --c "$last_commit_log"
 
       - name: Update READMEs
         run: python ci/generate_tutorial_readmes.py

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install -r requirements.txt
-          pip install nbconvert pillow
+          pip install nbconvert pillow fuzzywuzzy[speedup]
 
       - name: Install XKCD fonts
         run: |

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -48,8 +48,7 @@ jobs:
         run: |
           nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
           python ci/process_notebooks.py $nbs
-          readonly local last_commit_log=$(git log -1 --pretty=format:"%s")
-          echo $last_commit_log
+          readonly local last_commit_log=$(git log -2 --pretty=format:"%s")
           python ci/verify_exercises.py $nbs --c "$last_commit_log"
 
       - name: Update READMEs

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
           python ci/process_notebooks.py $nbs
-          if [[ ${{ github.event.head_commit.message }} != *"skip verify"* ]]; python ci/verify_exercises.py $nbs; fi
+          python ci/verify_exercises.py $nbs --c ${{ github.event.head_commit.message }}
 
       - name: Update READMEs
         run: python ci/generate_tutorial_readmes.py

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -48,7 +48,8 @@ jobs:
         run: |
           nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
           python ci/process_notebooks.py $nbs
-          python ci/verify_exercises.py $nbs --c ${{ github.event.head_commit.message }}
+          readonly local last_commit_log=$(git log -1 --pretty=format:"%s")
+          python ci/verify_exercises.py $nbs --c '$last_commit_log'
 
       - name: Update READMEs
         run: python ci/generate_tutorial_readmes.py

--- a/.github/workflows/tutorial-readme-pr.yaml
+++ b/.github/workflows/tutorial-readme-pr.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Update READMEs
         run: python ci/generate_tutorial_readmes.py
 
-      - name: Commit processed files
+      - name: Commit post-processed files
         if: ${{ success() }}
         run: |
           git config --local user.email "action@github.com"
@@ -35,7 +35,7 @@ jobs:
           git add '**/README.md'
           git diff-index --quiet HEAD || git commit -m "Update tutorial README"
 
-      - name: Push post-processed notebooks
+      - name: Push post-processed files
         if: ${{ success() }}
         uses: ad-m/github-push-action@v0.6.0
         with:

--- a/ci/select_notebooks.py
+++ b/ci/select_notebooks.py
@@ -1,0 +1,21 @@
+"""From a list of files, select process-able notebooks and print."""
+import os
+import sys
+
+if __name__ == "__main__":
+
+    _, *files = sys.argv
+
+    # Filter paths from the git manifest
+    # - Only process .ipynb
+    # - Don't process student notebooks
+    # - Don't process deleted notebooks
+    def should_process(path):
+        return all([
+            path.endswith(".ipynb"),
+            "student/" not in path,
+            os.path.isfile(path),
+        ])
+
+    nb_paths = [f for f in files if should_process(f)]
+    print(" ".join(nb_paths))

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -1,4 +1,19 @@
 #! /usr/bin/env python
+"""Check that exercise code matches solution code.
+
+Exercises are allowed to deivate from solutions in several ways:
+
+- Exercise code may replace solution code with an ellipsis (...)
+- Exercise code may have "commented-out" solution code
+
+Additionally:
+
+- Docstrings are currently ignored
+- Blank lines are ignored
+
+This script will report whether exercises and solutions otherwise match.
+
+"""
 import re
 import sys
 from textwrap import dedent
@@ -8,53 +23,78 @@ import nbformat
 
 def main(nb_fpath):
 
+    # Track overall status
+    failure = False
+
+    # Track the ordinal exercise cell number
+    # (note, exercises may be labeled differently in the notebook)
+    exercise = 0
+
+    # Load the notebook file
     with open(nb_fpath) as f:
         nb = nbformat.read(f, nbformat.NO_CONVERT)
 
-    exercise = 0
     for i, cell in enumerate(nb.get("cells", [])):
 
+        # Detect solution cells based on removal tag
         if has_solution(cell):
-
             exercise += 1
 
+            # Find a corresponding exercise cell
+            # (Assume it is the previous *code* cell)
             j = 1
+            stub_cell = None
             while (i - j):
                 stub_cell = nb["cells"][i - j]
                 if stub_cell["cell_type"] == "code":
+                    stub_cell = None
                     break
                 j += 1
+            if stub_cell is None:
+                continue
 
+            # Extract the code and comments from both cells
             stub_code, stub_comments = logical_lines(stub_cell["source"])
             solu_code, solu_comments = logical_lines(cell["source"])
 
+            # Identify violations in the exercise cell
             unmatched_code = unmatched_lines(stub_code, solu_code)
             unmatched_comments = unmatched_lines(
                 stub_comments, solu_code + solu_comments
             )
 
-            print("-" * 60)
+            # Report the outcome for this exercise
+            print("-" * 69)
             print(f"Exercise {exercise}")
             report("Code", unmatched_code)
             report("Comment", unmatched_comments)
+            if unmatched_code or unmatched_comments:
+                failure = True
+
+    # Print overall summary and exit with return code
+    message = "Failure" if failure else "Success"
+    print("=" * 30, message, "=" * 30)
+    sys.exit(failure)
 
 
 def report(kind, unmatched, thresh=50):
-
-    if not unmatched:
-        print(f"{kind}: All perfect")
+    """Print information about code or comments in an exercise."""
+    if unmatched:
+        print(f"{kind}: FAIL")
+    else:
+        print(f"{kind}: PASS")
     for (score, stub, solu) in unmatched:
         if score < thresh:
-            print(f"{kind} without close match:")
-            print(f"* {stub}")
+            print(f" {kind} without close match:")
+            print(f" * {stub}")
         else:
-            print(f"{kind} with close mismatch ({score}%)")
-            print(f"+ {stub}")
-            print(f"- {solu}")
+            print(f" {kind} with close mismatch ({score}%)")
+            print(f" + {stub}")
+            print(f" - {solu}")
 
 
 def logical_lines(func_str):
-
+    """Extract code and block comments from cell string."""
     # Standardize docstring string format
     func_str = func_str.replace("'''", '"""')
 
@@ -69,10 +109,10 @@ def logical_lines(func_str):
 
     for line in func_str.split("\n"):
 
-        # Detect and ignore non-assigned block strings:
+        # Detect and ignore lines within two kinds of multi-line comments
         # - triple quotes (docstrings)
         # - comment hashmark fences
-        comment_block_fence = dedent(line).startswith('"""') or "#####" in line
+        comment_block_fence = dedent(line).startswith('"""') or "###" in line
         if reading_block_comment:
             if comment_block_fence:
                 reading_block_comment = False
@@ -85,12 +125,12 @@ def logical_lines(func_str):
         match = pattern.match(line)
         if match:
 
-            # Use nonn-commented component of the line
+            # Use nonn-commented component of a lie with inline comments
             code_line = match.group(1)
             comment_line = match.group(2)
 
             # Handle xkcd context, which is always last thing in solution cell
-            if "with plt.xkcd()" in code_line:
+            if "plt.xkcd()" in code_line:
                 making_xkcd_plot = True
                 continue
             if making_xkcd_plot:
@@ -108,21 +148,25 @@ def logical_lines(func_str):
 
 
 def unmatched_lines(stub_lines, solu_lines):
-
+    """Identify lines in the exercise stub without a match in the solution."""
     unmatched = []
 
     for stub_line in stub_lines:
 
+        # When we don't match, we want to track lines that are close
         best_score = 0
         best_line = ""
 
         for line in solu_lines:
 
+            # Match whole lines or parts of lines that need completion
             if "..." in stub_line:
                 part_scores = []
                 for part in stub_line.split("..."):
+                    if not part:
+                        continue
                     part_scores.append(fuzz.partial_ratio(part, line))
-                score = max(part_scores)
+                score = min(part_scores)
             else:
                 score = fuzz.ratio(stub_line, line)
 
@@ -130,6 +174,7 @@ def unmatched_lines(stub_lines, solu_lines):
                 best_score = score
                 best_line = line
 
+        # Track all lines that are not perfect matches
         if best_score < 100:
             unmatched.append((best_score, stub_line, best_line))
 
@@ -137,13 +182,13 @@ def unmatched_lines(stub_lines, solu_lines):
 
 
 def skip_code(line):
-
+    """Return True if a code line should be skipped based on contents."""
     line = dedent(line)
     return not line or "NotImplementedError" in line
 
 
 def skip_comment(line):
-
+    """Return True if a comment line should be skipped based on contents."""
     line = dedent(line)
     return not line or "to_remove" in line or "uncomment" in line.lower()
 

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -1,0 +1,169 @@
+#! /usr/bin/env python
+import re
+import sys
+from textwrap import dedent
+from fuzzywuzzy import fuzz
+import nbformat
+
+
+def main(nb_fpath):
+
+    with open(nb_fpath) as f:
+        nb = nbformat.read(f, nbformat.NO_CONVERT)
+
+    exercise = 0
+    for i, cell in enumerate(nb.get("cells", [])):
+
+        if has_solution(cell):
+
+            exercise += 1
+
+            j = 1
+            while (i - j):
+                stub_cell = nb["cells"][i - j]
+                if stub_cell["cell_type"] == "code":
+                    break
+                j += 1
+
+            stub_code, stub_comments = logical_lines(stub_cell["source"])
+            solu_code, solu_comments = logical_lines(cell["source"])
+
+            unmatched_code = unmatched_lines(stub_code, solu_code)
+            unmatched_comments = unmatched_lines(
+                stub_comments, solu_code + solu_comments
+            )
+
+            print("-" * 88)
+            print(f"Exercise {exercise}")
+            report("Code", unmatched_code)
+            report("Comment", unmatched_comments)
+
+
+def report(kind, unmatched, thresh=50):
+
+    if not unmatched:
+        print(f"{kind}: All perfect")
+    for (score, stub, solu) in unmatched:
+        if score < thresh:
+            print(f"{kind} without close match:")
+            print(f"* {stub}")
+        else:
+            print(f"{kind} with close mismatch ({score}%)")
+            print(f"+ {stub}")
+            print(f"- {solu}")
+
+
+def logical_lines(func_str):
+
+    # Standardize docstring string format
+    func_str = func_str.replace("'''", '"""')
+
+    # Define a regular expression to remove comments
+    pattern = re.compile(r"^([^#]*)\s*#*\s*(.*?)\s*$")
+
+    code_lines = []
+    comment_lines = []
+
+    making_xkcd_plot = False
+    reading_block_comment = False
+
+    for line in func_str.split("\n"):
+
+        # Detect and ignore non-assigned block strings:
+        # - triple quotes (docstrings)
+        # - comment hashmark fences
+        comment_block_fence = dedent(line).startswith('"""') or "#####" in line
+        if reading_block_comment:
+            if comment_block_fence:
+                reading_block_comment = False
+            continue
+        else:
+            if comment_block_fence:
+                reading_block_comment = True
+                continue
+
+        match = pattern.match(line)
+        if match:
+
+            # Use nonn-commented component of the line
+            code_line = match.group(1)
+            comment_line = match.group(2)
+
+            # Handle xkcd context, which is always last thing in solution cell
+            if "with plt.xkcd()" in code_line:
+                making_xkcd_plot = True
+                continue
+            if making_xkcd_plot:
+                code_line = dedent(code_line)
+
+            # Check for reasons to ignore the line, otherwise keep it
+
+            if not skip_code(code_line):
+                code_lines.append(code_line)
+
+            if not dedent(code_line) and not skip_comment(comment_line):
+                comment_lines.append(comment_line)
+
+    return code_lines, comment_lines
+
+
+def unmatched_lines(stub_lines, solu_lines):
+
+    unmatched = []
+
+    for stub_line in stub_lines:
+
+        best_score = 0
+        best_line = ""
+
+        for line in solu_lines:
+
+            if "..." in stub_line:
+                part_scores = []
+                for part in stub_line.split("..."):
+                    part_scores.append(fuzz.partial_ratio(part, line))
+                score = max(part_scores)
+            else:
+                score = fuzz.ratio(stub_line, line)
+
+            if score > best_score:
+                best_score = score
+                best_line = line
+
+        if best_score < 100:
+            unmatched.append((best_score, stub_line, best_line))
+
+    return unmatched
+
+
+def skip_code(line):
+
+    line = dedent(line)
+    return not line or "NotImplementedError" in line
+
+
+def skip_comment(line):
+
+    line = dedent(line)
+    return not line or "to_remove" in line or "uncomment" in line.lower()
+
+
+def has_solution(cell):
+    """Return True if cell is marked as containing an exercise solution."""
+    cell_text = cell["source"].replace(" ", "").lower()
+    first_line = cell_text.split("\n")[0]
+    return (
+        cell_text.startswith("#@titlesolution")
+        or "to_remove" in first_line
+        and "explanation" not in first_line
+    )
+
+
+if __name__ == "__main__":
+
+    try:
+        _, nb_fpath = sys.argv
+    except Exception:
+        sys.exit("USAGE: python verify_exercies.py <nb_fpath>")
+
+    main(nb_fpath)

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -33,7 +33,7 @@ def main(nb_fpath):
                 stub_comments, solu_code + solu_comments
             )
 
-            print("-" * 88)
+            print("-" * 60)
             print(f"Exercise {exercise}")
             report("Code", unmatched_code)
             report("Comment", unmatched_comments)

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -27,7 +27,7 @@ def main(arglist):
 
     args = parse_args(arglist)
 
-    if "skip verify" in args.commit_message:
+    if "skip verification" in args.commit_message:
         # Putting this logic here as I didn't have time to figure
         # out how to do it in the github actions workflow
         print("Skipping exercise verification")
@@ -125,11 +125,6 @@ def logical_lines(func_str):
 
     for line in func_str.split("\n"):
 
-        # Detect and ignore single-line docstrings
-        text = line.strip()
-        if text.startswith('"""') and text.endswith('"""'):
-            continue
-
         # Detect and ignore lines within multi-line comments
         # - triple quotes (docstrings)
         # - comment hashmark fences
@@ -139,6 +134,12 @@ def logical_lines(func_str):
                 reading_block_comment = False
             continue
         else:
+
+            # Detect and ignore single-line docstrings
+            text = line.strip()
+            if text.startswith('"""') and text.endswith('"""'):
+                continue
+
             if comment_block_fence:
                 reading_block_comment = True
                 continue

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -115,11 +115,7 @@ def logical_lines(func_str):
     func_str = func_str.replace("'''", '"""')
 
     # Define a regular expression to remove comments
-    pattern = re.compile(r"^([^#]*)\s*#*\s*(.*?)\s*$")
-
-    # TODO: An issue: for commented code, this ignores leading
-    # whitespace, but for uncommented code, it keeps it.
-    # This needs a little thinking about the best solution.
+    pattern = re.compile(r"^([^#]*)\s*#* {0,1}(.*?)\s*$")
 
     code_lines = []
     comment_lines = []
@@ -160,7 +156,7 @@ def logical_lines(func_str):
                 making_xkcd_plot = True
                 continue
             if making_xkcd_plot:
-                code_line = dedent(code_line)
+                code_line = code_line[2:]
 
             # Check for reasons to ignore the line, otherwise keep it
 

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -27,6 +27,9 @@ def main(arglist):
 
     args = parse_args(arglist)
 
+    print("Commit message:")
+    print(args.commit_message)
+    print()
     if "skip verify" in args.commit_message:
         # Putting this logic here as I didn't have time to figure
         # out how to do it in the github actions workflow

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -93,7 +93,7 @@ def main(arglist):
 def report(exercise, code, comment, thresh=50):
     """Print information about unmatched code and comments in an exercise."""
     code_status = "FAIL" if code else "PASS"
-    comment_status = "FAIL" if code else "PASS"
+    comment_status = "FAIL" if comment else "PASS"
     print(
         f"Exercise {exercise} | Code {code_status} | Comments {comment_status}"
     )

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -29,7 +29,6 @@ def main(arglist):
 
     print("Commit message:")
     print(args.commit_message)
-    print()
     if "skip verify" in args.commit_message:
         # Putting this logic here as I didn't have time to figure
         # out how to do it in the github actions workflow

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -27,8 +27,6 @@ def main(arglist):
 
     args = parse_args(arglist)
 
-    print("Commit message:")
-    print(args.commit_message)
     if "skip verify" in args.commit_message:
         # Putting this logic here as I didn't have time to figure
         # out how to do it in the github actions workflow
@@ -127,7 +125,12 @@ def logical_lines(func_str):
 
     for line in func_str.split("\n"):
 
-        # Detect and ignore lines within two kinds of multi-line comments
+        # Detect and ignore single-line docstrings
+        text = line.strip()
+        if text.startswith('"""') and text.endswith('"""'):
+            continue
+
+        # Detect and ignore lines within multi-line comments
         # - triple quotes (docstrings)
         # - comment hashmark fences
         comment_block_fence = dedent(line).startswith('"""') or "###" in line

--- a/ci/verify_exercises.py
+++ b/ci/verify_exercises.py
@@ -117,6 +117,10 @@ def logical_lines(func_str):
     # Define a regular expression to remove comments
     pattern = re.compile(r"^([^#]*)\s*#*\s*(.*?)\s*$")
 
+    # TODO: An issue: for commented code, this ignores leading
+    # whitespace, but for uncommented code, it keeps it.
+    # This needs a little thinking about the best solution.
+
     code_lines = []
     comment_lines = []
 


### PR DESCRIPTION
This script checks that exercise code matches solution code, up to the presence of ellipses and commented/uncommented code.

I am adding this to the CI, and it will reject pull requests with exercises that fail verification. BUT: this is tricky and probably has some kinks to work out. **So it should be possible to skip by including `skip verification` in the commit message.**

Here's an example report, using a somewhat older version of W1D4 (I fixed most of these yesterday). Note that some of the apparent mismatches are caused by trailing whitespace; I don't have a good way of making that obvious in the report yet.

```
$ python ci/verify_exercises.py tutorials/W1D4_MachineLearning/*.ipynb

---W1D4_Tutorial1.ipynb--------------------------------------------
Exercise 1 | Code FAIL | Comments FAIL
  Code with close mismatch (98%)
  +   padded_stim = np.concatenate([np.zeros(d - 1), stim])
  -   padded_stim = np.concatenate([np.zeros(d - 1), stim])
  Code with close mismatch (67%)
  +   T = len(...)
  -   T = len(stim)
  Code with close mismatch (62%)
  +   return X
  -   return X
  Comment without close match:
  * Create version of stimulus vector with zeros before onset
  Comment without close match:
  * Construct a matrix where each row has the d frames of
  Comment without close match:
  * the stimulus proceeding and including timepoint t
Exercise 2 | Code PASS | Comments PASS
  Comment without close match:
  * Create the design matrix
  Comment without close match:
  * Get the MLE weights for the LG model
  Comment with close mismatch (51%)
  + Compute predicted spike counts
  - def predict_spike_counts_lg(stim, spikes, d=25):
Exercise 3 | Code FAIL | Comments FAIL
  Code with close mismatch (79%)
  + def fit_lnp(X, y, d=25):
  - def fit_lnp(stim, spikes, d=25):
  Code with close mismatch (89%)
  +   constant = np.ones_like(y)
  -   constant = np.ones_like(spikes)
  Comment without close match:
  * Compute the Poisson log likeliood
  Comment without close match:
  * Build the design matrix
  Comment without close match:
  * Use a random vector of weights to start (mean 0, sd .2)
  Comment without close match:
  * Find parameters that minmize the negative log likelihood function
  Comment with close mismatch (92%)
  + theta_lnp = fit_lnp(X, spikes)
  - theta_lnp = fit_lnp(stim, spikes)
Exercise 4 | Code FAIL | Comments FAIL
  Code with close mismatch (95%)
  +   if theta is None:
  -   if theta is None:

---W1D4_Tutorial2.ipynb--------------------------------------------
Exercise 1 | Code PASS | Comments PASS
  Comment without close match:
  * TODO for students: Fill in the missing code (...) and remove the error
Exercise 2 | Code PASS | Comments PASS
  Comment with close mismatch (99%)
  + print(f"Accuracy on the training data: {train_accuracy:.2%}%")
  - print(f"Accuracy on the training data: {train_accuracy:.2%}")
Exercise 3 | Code PASS | Comments PASS
Exercise 4 | Code PASS | Comments PASS
  Comment without close match:
  * (Hint, you may need to set max_iter)
  Comment without close match:
  * Use log-spaced values for C

============================== Failure ==============================
```