### PR TITLE
Don't specify CI requirements in course environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,4 @@ dependencies:
   - scikit-learn
   - pytorch
   - ipywidgets
-  - flake8
   - pip
-  - pip:
-    - fuzzywuzzy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ matplotlib
 scikit-learn
 torch
 ipywidgets
-flake8
-fuzzywuzzy


### PR DESCRIPTION
`fuzzywuzzy` (not the bear).
Pip says: "fuzzywuzzy? where?!"
"The environment we share?"
No pip, you won't find it there.
