### PR TITLE
Don't merge master into feature branch during CI

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/tutorial-readme-pr.yaml
+++ b/.github/workflows/tutorial-readme-pr.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
This changes the CI workflow so that the master branch does not get merged into the feature branch during CI.

The reasons you would do this (it's the default behavior) are two-fold:

1. The feature branch always gets the latest CI tooling
2. You test the new code in the context of the package after a merge, rather than w/r/t when the feature branch originated

(1) is useful to us, but less so now that CI development has largely stabilized.
(2) is not especially useful because there are not dependencies between days (or even notebooks).

The major downside to merging master into a CI workflow that pushes back to the feature branch are that we get lots of noise in the diff ([only in the github view](https://stackoverflow.com/questions/16306012/github-pull-request-showing-commits-that-are-already-in-target-branch)). This makes the already-difficult challenge of understanding what changes a PR will make nearly impossible. We have also on occasion gotten a merge conflict.

On balance, I think this change will be preferable.