### PR TITLE
Only look 1 commit back for 'skip verification' message

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files}}`
           python ci/process_notebooks.py $nbs
-          readonly local last_commit_log=$(git log -2 --pretty=format:"%s")
+          readonly local last_commit_log=$(git log -1 --pretty=format:"%s")
           python ci/verify_exercises.py $nbs --c "$last_commit_log"
 
       - name: Update READMEs


### PR DESCRIPTION
Missed this in #450; I forgot that the "skip verification" handling checked two commits back because there was an intervening merge commit. Now that should not be necessary.