### PR TITLE
Add BSD3 license for  software elements

### DIFF
--- a/LICENSE-CODE.md
+++ b/LICENSE-CODE.md
@@ -1,0 +1,11 @@
+Copyright 2020 Neuromatch Academy
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -471,13 +471,21 @@ These are hour-long live-streamed events with a panel of speakers that will disc
 
 ----
 
-Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
-
-This work and everything in this repo is licensed under a [Creative Commons Attribution 4.0 International
-License][cc-by].
+## Licensing
 
 [![CC BY 4.0][cc-by-image]][cc-by]
+
+[![CC BY 4.0][cc-by-shield]][cc-by] [![BSD-3][bsd-3-shield]][bsd-3]
+
+The contents of this repository are shared under under a [Creative Commons Attribution 4.0 International License][cc-by].
+
+Software elements are additionally licensed under the [BSD (3-Clause) License][bsd-3].
+
+Derivative works may use the license that is more appropriate to the relevant context.
 
 [cc-by]: http://creativecommons.org/licenses/by/4.0/
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
+
+[bsd-3]: https://opensource.org/licenses/BSD-3-Clause
+[bsd-3-shield]: https://camo.githubusercontent.com/9b9ea65d95c9ef878afa1987df65731d47681336/68747470733a2f2f696d672e736869656c64732e696f2f707970692f6c2f736561626f726e2e737667


### PR DESCRIPTION
This leaves the full repository licensed under CC-BY and dual-licenses the software elements under BSD3.

I believe this satisfies the JOSE licensing requirements and makes it easier for downstream software projects to use code from the notebooks (or infrastructure code that lives in the repo) without the complexity of dealing with the CC-BY license.

The dual license is a bit more complicated, but I think it's the right approach given the diversity of content in the NMA notebooks.