### PR TITLE
Update tutorial CI workflow to ignore NotImplementedError exceptions

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Get commit message
         run: |
           readonly local msg=$(git log -1 --pretty=format:"%s")
-          echo "::set-env name=COMMIT_MESSAGE::$msg"
+          echo "COMMIT_MESSAGE=$msg" >> $GITHUB_ENV
 
       - name: Set up Python
         if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"

--- a/ci/process_notebooks.py
+++ b/ci/process_notebooks.py
@@ -55,6 +55,11 @@ class NMAPreprocessor(ExecutePreprocessor):
     # for errors with a private method (_check_raise_for_error). It would be cleaner
     # to customize only the error handling method, but alas, that is not allowed.
 
+    # The nbconvert.ExecutePreprocessor class inherits from both
+    # nbconvert.Preprocessor and nbclient.NotebookClient. The relevant methods that we
+    # patch are defined on the latter. The code here was taken from this specific tag:
+    # https://github.com/jupyter/nbclient/blob/0.5.1/nbclient/client.py
+
     async def async_execute_cell(
             self,
             cell: nbformat.NotebookNode,
@@ -180,7 +185,10 @@ class NMAPreprocessor(ExecutePreprocessor):
 
         if execution_count:
             cell['execution_count'] = execution_count
+
+        # -- NMA-specific code here -- #
         self._check_raise_for_error_nma(cell, exec_reply)
+
         self.nb['cells'][cell_index] = cell
         return cell
 
@@ -196,7 +204,9 @@ class NMAPreprocessor(ExecutePreprocessor):
 
             if (exec_reply is not None) and exec_reply['content']['status'] == 'error':
 
+                # -- NMA-specific code here -- #
                 if exec_reply['content']['ename'] != 'NotImplementedError':
+
                     raise CellExecutionError.from_cell_and_msg(cell,
                                                                exec_reply['content'])
 

--- a/ci/process_notebooks.py
+++ b/ci/process_notebooks.py
@@ -78,7 +78,7 @@ def main(arglist):
             nb = nbformat.read(f, nbformat.NO_CONVERT)
 
         if not sequentially_executed(nb):
-            if args.require_sequntial:
+            if args.require_sequential:
                 err = (
                     "Notebook is not sequentially executed on a fresh kernel."
                     "\n"
@@ -578,7 +578,7 @@ def parse_args(arglist):
     parser.add_argument(
         "--allow-non-sequential",
         action="store_false",
-        dest="require_sequntial",
+        dest="require_sequential",
         help="Don't fail if the notebook is not sequentially executed"
     )
     return parser.parse_args(arglist)

--- a/ci/process_notebooks.py
+++ b/ci/process_notebooks.py
@@ -77,23 +77,20 @@ class NMAPreprocessor(ExecutePreprocessor):
         store_history : bool
             Determines if history should be stored in the kernel (default: False).
             Specific to ipython kernels, which can store command histories.
-        Returns
-        -------
-        output : dict
-            The execution output payload (or None for no output).
+
         Raises
         ------
         CellExecutionError
             If execution failed and should raise an exception, this will be raised
             with defaults about the failure.
+
         Returns
         -------
         cell : NotebookNode
             The cell which was just processed.
 
-        This method was copied from the nbclient library and modified to specifically
-        ignore NotImplementedError exceptions. The original code is under the following
-        license:
+        License
+        -------
 
         This project is licensed under the terms of the Modified BSD License
         (also known as New or Revised or 3-Clause BSD), as follows:


### PR DESCRIPTION
This change enhances the notebook processing workflow to ignore `NotImplementedError` exceptions when running through the instructor version of the notebook.

This change should allow us to avoid commenting-out code that depends on completed exercises. This is better for a few reasons:

- Students will encounter the `NotImplementedError` as they step through the tutorial, meaning that it will always be clear when they need to do something.
- Uncommenting code is annoying and prone to error, especially in Python where indentation level is semantic.
- The CI workflow can now verify that notebooks are written such that the only error a student should see with an incomplete exercise (note: not a "complete but wrong" exercise) is `NotImplementedError`. This is part of our style guide, but the CI workflow could not actually verify it.
- Avoiding the need to comment out code in exercises drastically simplifies the problem of doing exercise verification.

Almost all of the code in the diff is copied (with the license included) from the [nbclient](https://github.com/jupyter/nbclient) library. Unfortunately, the way the cell execution method is written, it calls out to a private method to do error handling. So our custom subclass patches both the public cell execution method and the private error handling method.

This basic approach could be extended to do other custom NMA things. For example, we could have the CI workflow be responsible for enabling XKCD mode on the solution cells.