### PR TITLE
fix: little typo in section number

### DIFF
--- a/tutorials/W1D3_ModelFitting/W1D3_Tutorial4.ipynb
+++ b/tutorials/W1D3_ModelFitting/W1D3_Tutorial4.ipynb
@@ -819,7 +819,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Section 2.4: Evaluating fit quality\n",
+    "## Section 2.3: Evaluating fit quality\n",
     "\n",
     "As with linear regression, we can compute mean squared error (MSE) to get a sense of how well the model fits the data. \n",
     "\n",


### PR DESCRIPTION
I was going through the notebook for timing estimates and found this little typo (section 2.4 after section 2.2, instead of section 2.3), so fixed the typo.

Thanks