### PR TITLE
Code to hide cells in jupyterbook

### DIFF
--- a/ci/generate_book.py
+++ b/ci/generate_book.py
@@ -80,6 +80,7 @@ def pre_process_notebook(file_path):
         with open(file_path, encoding="utf-8") as read_notebook:
             content = json.load(read_notebook)
         pre_processed_content = open_in_colab_new_tab(content)
+        pre_processed_content = link_hidden_cells(pre_processed_content)
         with open(file_path, "w", encoding="utf-8") as write_notebook:
             json.dump(pre_processed_content, write_notebook, indent=1, ensure_ascii=False)
     except Exception:
@@ -94,6 +95,22 @@ def open_in_colab_new_tab(content):
         # Open in new tab
         anchor['target'] = '_blank'
     cells[0]['source'][0] = str(parsed_html)
+    return content
+
+
+def link_hidden_cells(content):
+    cells = content['cells']
+    for cell in cells:
+        if "source" not in cell:
+            continue
+        source = cell['source'][0]
+        if source.startswith("#@title") or source.startswith("# @title"):
+            if 'metadata' not in cell:
+                cell['metadata'] = {}
+            if 'tags' not in cell['metadata']:
+                cell['metadata']['tags'] = []
+            if "hide-input" not in cell['metadata']['tags']:
+                cell['metadata']['tags'].append("hide-input")
     return content
 
 


### PR DESCRIPTION
Adding code to hide cells that start with #@title or # @title.
Adds 'tags:["hide-input"] ' to the cell's metadata.