### PR TITLE
Fixed jupyterbook layout issues with solution figures

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -2,7 +2,9 @@ name: notebook-pr
 on: 
   pull_request:
     branches: master
-    paths: '**/*.ipynb'
+    paths: 
+      - '**/*.ipynb'
+      - ci/process_notebooks.py
 
 env:
   NB_KERNEL: python

--- a/ci/process_notebooks.py
+++ b/ci/process_notebooks.py
@@ -229,17 +229,23 @@ def extract_solutions(nb, nb_dir, nb_name):
                     w = img.width // (dpi_w // 72)
                     h = img.height // (dpi_h // 72)
 
-                    tag_args = " ".join([
+                   tag_args = " ".join([
                         "alt='Solution hint'",
-                        "align='left'",
+                        "align='center'",
                         f"width={w}",
                         f"height={h}",
                         f"src={url}",
                     ])
+
                     new_source += f"<img {tag_args}>\n\n"
+                    new_source += f"<br>" # adds newline after html image, fixing layout
 
             cell["source"] = new_source
             cell["cell_type"] = "markdown"
+            # Alternative way to generate full-width (large) solution figures
+            #cell_tags = cell.get('metadata', {}).get('tags', [])
+            #cell_tags.append("full-width")
+            #cell['metadata']['tags'] = cell_tags
             cell["metadata"]["colab_type"] = "text"
             if "outputID" in cell["metadata"]:
                 del cell["metadata"]["outputId"]


### PR DESCRIPTION
Only edited the extract_solutions function in ci/process_notebooks.py by adding a
(newline) after the html solution image. Comment code below this change provides an alternatively solution using the "fixed-width" metadata tag for the cell; you also have to uncomment the code specifying the width/height args passed into the html  tag. The solution images this method generates are larger than ideal, but solves the layout issue too.