### PR TITLE
Local book readme fix

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -38,7 +38,7 @@ In order to build the book locally, you will need to do the following:
 
 `cp ../precourse/tutorials/W0D* tutorials/`
 
-`python ../nmaci/scripts/generate_book.py`
+`python ../nmaci/scripts/generate_book.py .`
 
 This will use the modified tutorials/materials.yml to create the `_toc.yml` file in the book directory. It will also be responsible for creating any additional markdown files or modifying any tutorial notebooks specifically for book generation. 
 

--- a/book/README.md
+++ b/book/README.md
@@ -16,6 +16,8 @@ In order to build the book locally, you will need to do the following:
 
 2. Install dependencies
 
+`cd course-content`
+
 `pip install -r ../nmaci/requirements.txt`
 
 `pip install jupyter-book==0.10.2`
@@ -24,15 +26,17 @@ In order to build the book locally, you will need to do the following:
 
 3. Create a symlink in the book dir to the tutorials dir. From the repo (i.e., course-content) root directory:
    
-`ln -s ../tutorials book/tutorials`
+`ln -s tutorials book/tutorials`
 
-`ln -s ../projects book/projects`
+`ln -s projects book/projects`
 
 4. Concatenate precourse and course-content `materials.yml` files, and prepare repo for book building 
 
 `cat ../precourse/tutorials/materials.yml tutorials/materials.yml > out.yml`
 
 `mv out.yml tutorials/materials.yml`
+
+`cp ../precourse/tutorials/W0D* tutorials/`
 
 `python ../nmaci/scripts/generate_book.py`
 
@@ -42,6 +46,6 @@ This will use the modified tutorials/materials.yml to create the `_toc.yml` file
 
 5. Build the book
 
-`jupyer-book build book`
+`jupyter-book build book`
 
 This will create a `book/_build` directory. You can open the `index.html` in any browser to verify the book.


### PR DESCRIPTION
Some small fixes to the instructions for building jupyterbook locally:

- It was a bit unclear where all the commands should be run. So added a `cd course-content`.
- Therefore, symlinks in `book/tutorials` and `book/projects` should point to `tutorials` and `projects` in the current directory i.e. `course-content` (instead of a level-up).
- `tutorials` did not have the precourse content. So added explicit instructions to copy those directories (namely `W0D*`) from `../precourse/tutorials` to `tutorials` in the current directory.
- `../nmaci/scripts/generate_book.py` needs an argument. So changed it to `python ../nmaci/scripts/generate_book.py .`
- Fixed a typo.