### PR TITLE
Fixed incorrect docstring for A_minus

### DIFF
--- a/tutorials/W2D3_BiologicalNeuronModels/solutions/W2D3_Tutorial4_Solution_91520015.py
+++ b/tutorials/W2D3_BiologicalNeuronModels/solutions/W2D3_Tutorial4_Solution_91520015.py
@@ -7,7 +7,7 @@ def Delta_W(pars, A_plus, A_minus, tau_stdp):
     A_plus     : (float) maximum amount of synaptic modification
                  which occurs when the timing difference between pre- and
                  post-synaptic spikes is positive
-    A_plus     : (float) maximum amount of synaptic modification
+    A_minus     : (float) maximum amount of synaptic modification
                  which occurs when the timing difference between pre- and
                  post-synaptic spikes is negative
     tau_stdp   : the ranges of pre-to-postsynaptic interspike intervals


### PR DESCRIPTION
Replaced A_plus that was appearing twice in the docstring by the correct param A_minus