### PR TITLE
Fix date formatting in download_slides.yml

### DIFF
--- a/.github/workflows/download_slides.yml
+++ b/.github/workflows/download_slides.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Get update date
         id: last_update
         run: |
-          last_update=$(echo @${{ github.event.repository.pushed_at}}| cut -c -10)
+          last_update=$(echo ${{ github.event.repository.pushed_at}}| cut -c -10)
           echo "last_update=$last_update" >> $GITHUB_OUTPUT
 
       - name: Upload full set of slides

--- a/.github/workflows/download_slides.yml
+++ b/.github/workflows/download_slides.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Get update date
         id: last_update
         run: |
-          last_update=$(date -Idate --date=@${{ github.event.repository.pushed_at}})
+          last_update=$(echo @${{ github.event.repository.pushed_at}}| cut -c -10)
           echo "last_update=$last_update" >> $GITHUB_OUTPUT
 
       - name: Upload full set of slides


### PR DESCRIPTION
For some reason, the date of the last commit returned by github was a "number of seconds since 1970" in my branch, but seems to be a regular date on the main branch.