### PR TITLE
Remove redundant sponsor logos

### DIFF
--- a/tutorials/Bonus_Autoencoders/Bonus_Intro.ipynb
+++ b/tutorials/Bonus_Autoencoders/Bonus_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/Bonus_Autoencoders/Bonus_Outro.ipynb
+++ b/tutorials/Bonus_Autoencoders/Bonus_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Bonus_Autoencoders/Bonus_Tutorial1.ipynb
+++ b/tutorials/Bonus_Autoencoders/Bonus_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/Bonus_Autoencoders/Bonus_Tutorial2.ipynb
+++ b/tutorials/Bonus_Autoencoders/Bonus_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/Bonus_Autoencoders/Bonus_Tutorial3.ipynb
+++ b/tutorials/Bonus_Autoencoders/Bonus_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/Module_WrapUps/DynamicalSystems.ipynb
+++ b/tutorials/Module_WrapUps/DynamicalSystems.ipynb
@@ -29,15 +29,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "## Podcast Panel Discussion\n",
     "\n",
     "Neuromatch Academy has collaborated with Paul Middlebrooks of the podcast Brain Inspired to host a series of panel discussions on the content modules. \n",

--- a/tutorials/Module_WrapUps/MachineLearning.ipynb
+++ b/tutorials/Module_WrapUps/MachineLearning.ipynb
@@ -29,15 +29,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "## Podcast Panel Discussion\n",
     "\n",
     "Neuromatch Academy has collaborated with Paul Middlebrooks of the podcast Brain Inspired to host a series of panel discussions on the content modules. \n",

--- a/tutorials/Module_WrapUps/StochasticProcesses.ipynb
+++ b/tutorials/Module_WrapUps/StochasticProcesses.ipynb
@@ -29,15 +29,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "## Podcast Panel Discussion\n",
     "\n",
     "Neuromatch Academy has collaborated with Paul Middlebrooks of the podcast Brain Inspired to host a series of panel discussions on the content modules. \n",

--- a/tutorials/W1D1_ModelTypes/W1D1_DaySummary.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D1_ModelTypes/W1D1_Intro.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W1D1_ModelTypes/W1D1_Outro.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D1_ModelTypes/W1D1_Tutorial1.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_Tutorial1.ipynb
@@ -40,15 +40,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "___\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D1_ModelTypes/W1D1_Tutorial2.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "___\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D1_ModelTypes/W1D1_Tutorial3.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_Tutorial3.ipynb
@@ -37,15 +37,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "___\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D1_ModelTypes/W1D1_Tutorial4.ipynb
+++ b/tutorials/W1D1_ModelTypes/W1D1_Tutorial4.ipynb
@@ -34,15 +34,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "___\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D2_ModelFitting/W1D2_DaySummary.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D2_ModelFitting/W1D2_Intro.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W1D2_ModelFitting/W1D2_Outro.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D2_ModelFitting/W1D2_Tutorial1.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "___\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D2_ModelFitting/W1D2_Tutorial2.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D2_ModelFitting/W1D2_Tutorial3.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D2_ModelFitting/W1D2_Tutorial4.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Tutorial4.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D2_ModelFitting/W1D2_Tutorial5.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Tutorial5.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D2_ModelFitting/W1D2_Tutorial6.ipynb
+++ b/tutorials/W1D2_ModelFitting/W1D2_Tutorial6.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D3_GeneralizedLinearModels/W1D3_DaySummary.ipynb
+++ b/tutorials/W1D3_GeneralizedLinearModels/W1D3_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D3_GeneralizedLinearModels/W1D3_Intro.ipynb
+++ b/tutorials/W1D3_GeneralizedLinearModels/W1D3_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W1D3_GeneralizedLinearModels/W1D3_Outro.ipynb
+++ b/tutorials/W1D3_GeneralizedLinearModels/W1D3_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D3_GeneralizedLinearModels/W1D3_Tutorial1.ipynb
+++ b/tutorials/W1D3_GeneralizedLinearModels/W1D3_Tutorial1.ipynb
@@ -37,15 +37,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D3_GeneralizedLinearModels/W1D3_Tutorial2.ipynb
+++ b/tutorials/W1D3_GeneralizedLinearModels/W1D3_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_DaySummary.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_Intro.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_Outro.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial1.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial2.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial3.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial3.ipynb
@@ -34,15 +34,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial4.ipynb
+++ b/tutorials/W1D4_DimensionalityReduction/W1D4_Tutorial4.ipynb
@@ -34,15 +34,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D5_DeepLearning/W1D5_DaySummary.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D5_DeepLearning/W1D5_Intro.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W1D5_DeepLearning/W1D5_Outro.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W1D5_DeepLearning/W1D5_Tutorial1.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D5_DeepLearning/W1D5_Tutorial2.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D5_DeepLearning/W1D5_Tutorial3.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W1D5_DeepLearning/W1D5_Tutorial4.ipynb
+++ b/tutorials/W1D5_DeepLearning/W1D5_Tutorial4.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "In this tutorial, we will dive deeper into our decoding model from Tutorial 1 and we will fit a convolutional neural network directly to neural activities.\n"

--- a/tutorials/W2D1_ModelingPractice/W2D1_DaySummary.ipynb
+++ b/tutorials/W2D1_ModelingPractice/W2D1_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D1_ModelingPractice/W2D1_Intro.ipynb
+++ b/tutorials/W2D1_ModelingPractice/W2D1_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W2D1_ModelingPractice/W2D1_Outro.ipynb
+++ b/tutorials/W2D1_ModelingPractice/W2D1_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D1_ModelingPractice/W2D1_Tutorial1.ipynb
+++ b/tutorials/W2D1_ModelingPractice/W2D1_Tutorial1.ipynb
@@ -37,15 +37,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial objectives\n",
     "Yesterday you gained some understanding of what models can buy us in neuroscience. But how do you build a model? Today, we will try to clarify the process of computational modeling, by thinking through the logic of modeling based on your project ideas.\n",

--- a/tutorials/W2D2_LinearSystems/W2D2_DaySummary.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D2_LinearSystems/W2D2_Intro.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W2D2_LinearSystems/W2D2_Outro.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D2_LinearSystems/W2D2_Tutorial1.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D2_LinearSystems/W2D2_Tutorial2.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D2_LinearSystems/W2D2_Tutorial3.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_Tutorial3.ipynb
@@ -35,15 +35,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D2_LinearSystems/W2D2_Tutorial4.ipynb
+++ b/tutorials/W2D2_LinearSystems/W2D2_Tutorial4.ipynb
@@ -35,15 +35,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_DaySummary.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_Intro.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_Outro.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial1.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial2.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial2.ipynb
@@ -35,15 +35,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial3.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial4.ipynb
+++ b/tutorials/W2D3_BiologicalNeuronModels/W2D3_Tutorial4.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "In this tutorial, we will focus on building a model of a synapse in which its synaptic strength changes as a function of the relative timing (i.e., time difference) between the spikes of the presynaptic and postsynaptic neurons, respectively. This change in the synaptic weight is known as **spike-timing dependent plasticity (STDP)**.\n",

--- a/tutorials/W2D4_DynamicNetworks/W2D4_DaySummary.ipynb
+++ b/tutorials/W2D4_DynamicNetworks/W2D4_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D4_DynamicNetworks/W2D4_Intro.ipynb
+++ b/tutorials/W2D4_DynamicNetworks/W2D4_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W2D4_DynamicNetworks/W2D4_Outro.ipynb
+++ b/tutorials/W2D4_DynamicNetworks/W2D4_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W2D4_DynamicNetworks/W2D4_Tutorial1.ipynb
+++ b/tutorials/W2D4_DynamicNetworks/W2D4_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D4_DynamicNetworks/W2D4_Tutorial2.ipynb
+++ b/tutorials/W2D4_DynamicNetworks/W2D4_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W2D4_DynamicNetworks/W2D4_Tutorial3.ipynb
+++ b/tutorials/W2D4_DynamicNetworks/W2D4_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "In the previous tutorial, you learned about the **Wilson-Cowan** rate model. Here we will dive into some deeper analyses of this model.\n",

--- a/tutorials/W3D1_BayesianDecisions/W3D1_DaySummary.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D1_BayesianDecisions/W3D1_Intro.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W3D1_BayesianDecisions/W3D1_Outro.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial1.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "# Tutorial Objectives\n",
     "\n",
     "*Estimated timing of tutorial: 1 hour, 30 minutes*\n",

--- a/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial2.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "# Tutorial Objectives\n",
     "\n",
     "*Estimated timing of tutorial: 1 hour, 35 minutes*\n",

--- a/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial3.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial3.ipynb
@@ -40,15 +40,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial objectives\n",
     "\n",

--- a/tutorials/W3D2_HiddenDynamics/W3D2_DaySummary.ipynb
+++ b/tutorials/W3D2_HiddenDynamics/W3D2_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D2_HiddenDynamics/W3D2_Intro.ipynb
+++ b/tutorials/W3D2_HiddenDynamics/W3D2_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W3D2_HiddenDynamics/W3D2_Outro.ipynb
+++ b/tutorials/W3D2_HiddenDynamics/W3D2_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D2_HiddenDynamics/W3D2_Tutorial1.ipynb
+++ b/tutorials/W3D2_HiddenDynamics/W3D2_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "# Tutorial Objectives\n",
     "\n",
     "*Estimated timing of tutorial: 45 minutes*\n",

--- a/tutorials/W3D3_OptimalControl/W3D3_DaySummary.ipynb
+++ b/tutorials/W3D3_OptimalControl/W3D3_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D3_OptimalControl/W3D3_Intro.ipynb
+++ b/tutorials/W3D3_OptimalControl/W3D3_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W3D3_OptimalControl/W3D3_Outro.ipynb
+++ b/tutorials/W3D3_OptimalControl/W3D3_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D3_OptimalControl/W3D3_Tutorial1.ipynb
+++ b/tutorials/W3D3_OptimalControl/W3D3_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W3D3_OptimalControl/W3D3_Tutorial2.ipynb
+++ b/tutorials/W3D3_OptimalControl/W3D3_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_DaySummary.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_Intro.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_Outro.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial1.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "\n",
     "# Tutorial objectives\n",

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial2.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "\n",
     "# Tutorial Objectives\n",

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial3.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "\n",
     "# Tutorial Objectives\n",

--- a/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial4.ipynb
+++ b/tutorials/W3D4_ReinforcementLearning/W3D4_Tutorial4.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "\n",
     "# Tutorial Objectives\n",

--- a/tutorials/W3D5_NetworkCausality/W3D5_DaySummary.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_DaySummary.ipynb
@@ -26,15 +26,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D5_NetworkCausality/W3D5_Intro.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_Intro.ipynb
@@ -26,15 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "execution": {},
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/W3D5_NetworkCausality/W3D5_Outro.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_Outro.ipynb
@@ -24,15 +24,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/W3D5_NetworkCausality/W3D5_Tutorial1.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_Tutorial1.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial Objectives\n",
     "\n",

--- a/tutorials/W3D5_NetworkCausality/W3D5_Tutorial2.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_Tutorial2.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial objectives\n",
     "\n",

--- a/tutorials/W3D5_NetworkCausality/W3D5_Tutorial3.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_Tutorial3.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial objectives\n",
     "\n",

--- a/tutorials/W3D5_NetworkCausality/W3D5_Tutorial4.ipynb
+++ b/tutorials/W3D5_NetworkCausality/W3D5_Tutorial4.ipynb
@@ -36,15 +36,6 @@
     "execution": {}
    },
    "source": [
-    "<p align='center'><img src='https://github.com/NeuromatchAcademy/widgets/blob/master/sponsors.png?raw=True'/></p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
     "---\n",
     "# Tutorial objectives\n",
     "\n",


### PR DESCRIPTION
Massive search&replace so that only the main introduction page shows the sponsor logos (this seems to be consistent with the new tutorial material for Climatematch as well). 