### PR TITLE
Update pip in publish-book.yml

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -36,6 +36,7 @@ jobs:
           BRANCH=`python -c 'import os, re; m = re.search(r"nmaci:([\w-]+)", os.environ["COMMIT_MESSAGE"]); print("main" if m is None else m.group(1))'`
           wget https://github.com/NeuromatchAcademy/nmaci/archive/refs/heads/$BRANCH.tar.gz
           tar -xzf $BRANCH.tar.gz
+          pip install --upgrade pip
           pip install -r nmaci-$BRANCH/requirements.txt
           mv nmaci-$BRANCH/scripts/ ci/
           rm -r nmaci-$BRANCH


### PR DESCRIPTION
The installation of the feedback gadget looks a bit ugly at the moment, warning about a newer version of pip
![image](https://github.com/NeuromatchAcademy/course-content/assets/1381982/d83757a6-98ff-413d-a2ac-da5ad2f0d8a9)

In principle one can suppress this warning by passing ``disable-pip-version-check`` to the install command, but this would be needed in every notebook… I think it is easier to simply update the pip version when triggering the `publish_book.yml` workflow.