### PR TITLE
changed typecasting from np.float to float  in calc_loss_function

### DIFF
--- a/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial2.ipynb
+++ b/tutorials/W3D1_BayesianDecisions/W3D1_Tutorial2.ipynb
@@ -2081,7 +2081,7 @@
     "    elif loss_f == \"Absolute Error\":\n",
     "        loss = np.abs(error)\n",
     "    elif loss_f == \"Zero-One Loss\":\n",
-    "        loss = (np.abs(error) >= 0.03).astype(np.float)\n",
+    "        loss = (np.abs(error) >= 0.03).astype(float)\n",
     "    return loss"
    ]
   },


### PR DESCRIPTION
This PR solves Issue #1168 

#### Change highlight:
```
# @markdown Execute this cell to enable the function `calc_loss_func`

def calc_loss_func(loss_f, mu_true, x):
    # ...
    elif loss_f == "Zero-One Loss":
        loss = (np.abs(error) >= 0.03).astype(float)
    return loss
    
```

Changed from `astype(np.float)` to `astype(float)` in the function `calc_loss_func`.

This enables the interactive demo to show the plots for Zero-One Loss which was not possible before, as pointed out in the issue.

<img width="1397" height="793" alt="image" src="https://github.com/user-attachments/assets/d0c7bd6b-e6d4-4f11-b521-52e343805f15" />
